### PR TITLE
git commit -m "[bugfix]: v0.2.2: Issue 25 fix parser.py to fetch summary when the DBT Project has exactly 1 object;"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## v0.2.2
+
+- [bugfix]: Unable to detect summary when the DBT object are exactly one, like 1 model, 1 test, 1 seed file, 1 source, 1 operation, 1 macro, 1 analyse ; closes #25 @sudhirnune
+
 ## v0.2.1
 
 ### 🐛 Bug Fixes

--- a/src/dbt_log_parser/parser.py
+++ b/src/dbt_log_parser/parser.py
@@ -67,8 +67,8 @@ class DbtLogParser(metaclass=LoggingMixin):
         m = re.search("Running with dbt", line)
 
         m = re.search(
-            r"Found (\d+) models, (\d+) tests, (\d+) snapshots, (\d+) analyses, "
-            + r"(\d+) macros, (\d+) operations, (\d+) seed files, (\d+) sources",
+            r"Found (\d+) models?, (\d+) tests?, (\d+) snapshots?, (\d+) analyses?, "
+            + r"(\d+) macros?, (\d+) operations?, (\d+) seed files?, (\d+) sources?",
             line,
         )
 


### PR DESCRIPTION
## Bug Fix on parser.py, to detect summary record from DBT Log when DBT Project has only 1 Object for one or more object type

**Closes Issue**: #25

## Checklist

- [Y] GitHub issue code is in my PR title, branch name, and linked to from my PR description
- [Y] PR title starts with one of '[feature] ', '[bugfix] ', '[ci] ', '[chore] ', '[release] ', or '[docs] '
- [Y] I've added adequate documentation
- [Y] I've added adequate unit tests
- [Y] I've added the appropriate labels to my PR such that on merge it will be added to the correct section of the draft release by the [release drafter](https://github.com/marketplace/actions/release-drafter); see [./release-drafter.yml](./release-drafter.yml)
- [Y] I've added the appropriate milestone to my PR
